### PR TITLE
Add Apache 2.0 license and update README

### DIFF
--- a/LICENSE
+++ b/LICENSE
@@ -1,0 +1,201 @@
+                                 Apache License
+                           Version 2.0, January 2004
+                        http://www.apache.org/licenses/
+
+   TERMS AND CONDITIONS FOR USE, REPRODUCTION, AND DISTRIBUTION
+
+   1. Definitions.
+
+      "License" shall mean the terms and conditions for use, reproduction,
+      and distribution as defined by Sections 1 through 9 of this document.
+
+      "Licensor" shall mean the copyright owner or entity authorized by
+      the copyright owner that is granting the License.
+
+      "Legal Entity" shall mean the union of the acting entity and all
+      other entities that control, are controlled by, or are under common
+      control with that entity. For the purposes of this definition,
+      "control" means (i) the power, direct or indirect, to cause the
+      direction or management of such entity, whether by contract or
+      otherwise, or (ii) ownership of fifty percent (50%) or more of the
+      outstanding shares, or (iii) beneficial ownership of such entity.
+
+      "You" (or "Your") shall mean an individual or Legal Entity
+      exercising permissions granted by this License.
+
+      "Source" form shall mean the preferred form for making modifications,
+      including but not limited to software source code, documentation
+      source, and configuration files.
+
+      "Object" form shall mean any form resulting from mechanical
+      transformation or translation of a Source form, including but
+      not limited to compiled object code, generated documentation,
+      and conversions to other media types.
+
+      "Work" shall mean the work of authorship, whether in Source or
+      Object form, made available under the License, as indicated by a
+      copyright notice that is included in or attached to the work
+      (an example is provided in the Appendix below).
+
+      "Derivative Works" shall mean any work, whether in Source or Object
+      form, that is based on (or derived from) the Work and for which the
+      editorial revisions, annotations, elaborations, or other modifications
+      represent, as a whole, an original work of authorship. For the purposes
+      of this License, Derivative Works shall not include works that remain
+      separable from, or merely link (or bind by name) to the interfaces of,
+      the Work and Derivative Works thereof.
+
+      "Contribution" shall mean any work of authorship, including
+      the original version of the Work and any modifications or additions
+      to that Work or Derivative Works thereof, that is intentionally
+      submitted to Licensor for inclusion in the Work by the copyright owner
+      or by an individual or Legal Entity authorized to submit on behalf of
+      the copyright owner. For the purposes of this definition, "submitted"
+      means any form of electronic, verbal, or written communication sent
+      to the Licensor or its representatives, including but not limited to
+      communication on electronic mailing lists, source code control systems,
+      and issue tracking systems that are managed by, or on behalf of, the
+      Licensor for the purpose of discussing and improving the Work, but
+      excluding communication that is conspicuously marked or otherwise
+      designated in writing by the copyright owner as "Not a Contribution."
+
+      "Contributor" shall mean Licensor and any individual or Legal Entity
+      on behalf of whom a Contribution has been received by Licensor and
+      subsequently incorporated within the Work.
+
+   2. Grant of Copyright License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      copyright license to reproduce, prepare Derivative Works of,
+      publicly display, publicly perform, sublicense, and distribute the
+      Work and such Derivative Works in Source or Object form.
+
+   3. Grant of Patent License. Subject to the terms and conditions of
+      this License, each Contributor hereby grants to You a perpetual,
+      worldwide, non-exclusive, no-charge, royalty-free, irrevocable
+      (except as stated in this section) patent license to make, have made,
+      use, offer to sell, sell, import, and otherwise transfer the Work,
+      where such license applies only to those patent claims licensable
+      by such Contributor that are necessarily infringed by their
+      Contribution(s) alone or by combination of their Contribution(s)
+      with the Work to which such Contribution(s) was submitted. If You
+      institute patent litigation against any entity (including a
+      cross-claim or counterclaim in a lawsuit) alleging that the Work
+      or a Contribution incorporated within the Work constitutes direct
+      or contributory patent infringement, then any patent licenses
+      granted to You under this License for that Work shall terminate
+      as of the date such litigation is filed.
+
+   4. Redistribution. You may reproduce and distribute copies of the
+      Work or Derivative Works thereof in any medium, with or without
+      modifications, and in Source or Object form, provided that You
+      meet the following conditions:
+
+      (a) You must give any other recipients of the Work or
+          Derivative Works a copy of this License; and
+
+      (b) You must cause any modified files to carry prominent notices
+          stating that You changed the files; and
+
+      (c) You must retain, in the Source form of any Derivative Works
+          that You distribute, all copyright, patent, trademark, and
+          attribution notices from the Source form of the Work,
+          excluding those notices that do not pertain to any part of
+          the Derivative Works; and
+
+      (d) If the Work includes a "NOTICE" text file as part of its
+          distribution, then any Derivative Works that You distribute must
+          include a readable copy of the attribution notices contained
+          within such NOTICE file, excluding those notices that do not
+          pertain to any part of the Derivative Works, in at least one
+          of the following places: within a NOTICE text file distributed
+          as part of the Derivative Works; within the Source form or
+          documentation, if provided along with the Derivative Works; or,
+          within a display generated by the Derivative Works, if and
+          wherever such third-party notices normally appear. The contents
+          of the NOTICE file are for informational purposes only and
+          do not modify the License. You may add Your own attribution
+          notices within Derivative Works that You distribute, alongside
+          or as an addendum to the NOTICE text from the Work, provided
+          that such additional attribution notices cannot be construed
+          as modifying the License.
+
+      You may add Your own copyright statement to Your modifications and
+      may provide additional or different license terms and conditions
+      for use, reproduction, or distribution of Your modifications, or
+      for any such Derivative Works as a whole, provided Your use,
+      reproduction, and distribution of the Work otherwise complies with
+      the conditions stated in this License.
+
+   5. Submission of Contributions. Unless You explicitly state otherwise,
+      any Contribution intentionally submitted for inclusion in the Work
+      by You to the Licensor shall be under the terms and conditions of
+      this License, without any additional terms or conditions.
+      Notwithstanding the above, nothing herein shall supersede or modify
+      the terms of any separate license agreement you may have executed
+      with Licensor regarding such Contributions.
+
+   6. Trademarks. This License does not grant permission to use the trade
+      names, trademarks, service marks, or product names of the Licensor,
+      except as required for reasonable and customary use in describing the
+      origin of the Work and reproducing the content of the NOTICE file.
+
+   7. Disclaimer of Warranty. Unless required by applicable law or
+      agreed to in writing, Licensor provides the Work (and each
+      Contributor provides its Contributions) on an "AS IS" BASIS,
+      WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or
+      implied, including, without limitation, any warranties or conditions
+      of TITLE, NON-INFRINGEMENT, MERCHANTABILITY, or FITNESS FOR A
+      PARTICULAR PURPOSE. You are solely responsible for determining the
+      appropriateness of using or redistributing the Work and assume any
+      risks associated with Your exercise of permissions under this License.
+
+   8. Limitation of Liability. In no event and under no legal theory,
+      whether in tort (including negligence), contract, or otherwise,
+      unless required by applicable law (such as deliberate and grossly
+      negligent acts) or agreed to in writing, shall any Contributor be
+      liable to You for damages, including any direct, indirect, special,
+      incidental, or consequential damages of any character arising as a
+      result of this License or out of the use or inability to use the
+      Work (including but not limited to damages for loss of goodwill,
+      work stoppage, computer failure or malfunction, or any and all
+      other commercial damages or losses), even if such Contributor
+      has been advised of the possibility of such damages.
+
+   9. Accepting Warranty or Additional Liability. While redistributing
+      the Work or Derivative Works thereof, You may choose to offer,
+      and charge a fee for, acceptance of support, warranty, indemnity,
+      or other liability obligations and/or rights consistent with this
+      License. However, in accepting such obligations, You may act only
+      on Your own behalf and on Your sole responsibility, not on behalf
+      of any other Contributor, and only if You agree to indemnify,
+      defend, and hold each Contributor harmless for any liability
+      incurred by, or claims asserted against, such Contributor by reason
+      of your accepting any such warranty or additional liability.
+
+   END OF TERMS AND CONDITIONS
+
+   APPENDIX: How to apply the Apache License to your work.
+
+      To apply the Apache License to your work, attach the following
+      boilerplate notice, with the fields enclosed by brackets "[]"
+      replaced with your own identifying information. (Don't include
+      the brackets!)  The text should be enclosed in the appropriate
+      comment syntax for the file format. We also recommend that a
+      file or class name and description of purpose be included on the
+      same "printed page" as the copyright notice for easier
+      identification within third-party archives.
+
+   Copyright [yyyy] [name of copyright owner]
+
+   Licensed under the Apache License, Version 2.0 (the "License");
+   you may not use this file except in compliance with the License.
+   You may obtain a copy of the License at
+
+       http://www.apache.org/licenses/LICENSE-2.0
+
+   Unless required by applicable law or agreed to in writing, software
+   distributed under the License is distributed on an "AS IS" BASIS,
+   WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+   See the License for the specific language governing permissions and
+   limitations under the License.

--- a/README.md
+++ b/README.md
@@ -1,47 +1,86 @@
 # Skyroulette
 
-Petit service FastAPI + bot Discord qui propose un "spin" pour ban temporairement un membre.
+[![Python](https://img.shields.io/badge/python-3.11%2B-blue)](https://www.python.org/)
+[![License](https://img.shields.io/github/license/LosKeeper/skyroulette)](https://github.com/LosKeeper/skyroulette/blob/main/LICENSE)
+[![Stars](https://img.shields.io/github/stars/LosKeeper/skyroulette?style=social)](https://github.com/LosKeeper/skyroulette/stargazers)
+[![GitHub profile](https://img.shields.io/badge/GitHub-LosKeeper-181717?logo=github&logoColor=white)](https://github.com/LosKeeper)
+[![GitHub profile](https://img.shields.io/badge/GitHub-ThomasByr-181717?logo=github&logoColor=red)](https://github.com/ThomasByr)
 
-Installation
-- Installer les dépendances :
+A small web service combining a FastAPI backend and a Discord bot: the application offers a random "spin" which applies a temporary timeout (short ban) to an eligible member of a Discord guild.
 
-```bash
-pip install -r backend/requirements.txt
-```
+**Quick facts**
+- Language: Python 3.8+
+- Backend: FastAPI (REST API) + Discord bot (discord.py)
+- Frontend: static page (HTML/CSS/JS) served by the backend
+- Deployment: example systemd unit in `deploy/`
 
-Configuration
-- Créer un fichier `.env` dans `backend/` contenant au minimum :
+**Features**
+- Trigger a random spin via `POST /spin` to select an eligible member.
+- Persisted timeout history in `backend/timeouts.json`.
+- `GET /top-banned` endpoint: leaderboard of members with the most accumulated timeout time.
+- Configurable "Happy Hour": reduced timeout durations and shorter cooldowns.
 
-- `DISCORD_TOKEN` : token du bot Discord
-- `GUILD_ID` : identifiant du serveur (entier)
-- `ALLOWED_ORIGIN` (optionnel) : origine autorisée pour les requêtes depuis le frontend, par ex. `http://localhost:8000`. Si défini, le serveur refusera les POST vers `/spin` provenant d'une autre origine.
-- `ANNOUNCE_CHANNEL_ID` : identifiant du canal Discord où poster les annonces de spin (entier)
-- `START_HOUR_HAPPY_HOUR` (optionnel) : heure de début de la Happy Hour (format 24h, par défaut 17)
-- `END_HOUR_HAPPY_HOUR` (optionnel) : heure de fin de la Happy Hour (format 24h, par défaut 18)
+**Repository layout (high level)**
+- `backend/`: server and bot code (`main.py`, `state.py`, `timeouts_store.py`, `data.py`, `run.sh`, `requirements.txt`).
+- `frontend/`: static assets served at `/` (`index.html`, `roulette.js`, `style.css`).
+- `deploy/`: `skyroulette.service` example for systemd deployment.
 
-Exécution
-- Depuis la racine du projet :
+**Configuration (.env)**
+Create a `.env` file in `backend/` containing at least:
 
+- `DISCORD_TOKEN`: Discord bot token
+- `GUILD_ID`: target guild ID (integer)
+- `ANNOUNCE_CHANNEL_ID`: channel ID for spin announcements (optional)
+- `ALLOWED_ORIGIN`: allowed origin for requests from the frontend (optional)
+- `START_HOUR_HAPPY_HOUR`, `END_HOUR_HAPPY_HOUR`: daily happy hour start/end (24h, optional)
+
+Note: `backend/run.sh` reads `.env` and activates a local `venv` if present.
+
+**Quick start (development)**
 ```bash
 cd backend
-uvicorn main:app --reload --host 0.0.0.0 --port 8000
+python3 -m venv .venv
+source .venv/bin/activate
+pip install -r requirements.txt
+# copy and adapt .env
+./run.sh
 ```
 
-Le serveur FastAPI sert le frontend (route `/` et `/static`) et démarre le bot Discord en arrière-plan.
+`run.sh` launches `uvicorn` on `0.0.0.0:8000` and runs the Discord bot alongside the API.
 
-Endpoints principaux
-- `POST /spin` : lance un spin si possible. Le serveur applique une vérification d'origine si `ALLOWED_ORIGIN` est configuré.
-- `GET /status` : informations rapides (online, candidates, can_spin, history).
-- `GET /history` : historique enrichi des spins.
+**Important endpoints**
+- `GET /`: serves the frontend (`frontend/index.html`).
+- `POST /spin`: triggers a spin (origin check if `ALLOWED_ORIGIN` is set).
+- `GET /status`: quick status (online, candidates, can_spin, happy_hour, cooldown_seconds, history).
+- `GET /history`: enriched history of recent spins.
+- `GET /top-banned?limit=N`: top N members by total timeout seconds.
 
-Persistance et endpoints connexes
-- Le backend persiste l'historique des spins dans `backend/timeouts.json` via le module `backend/timeouts_store.py`. Le fichier est créé automatiquement et écrit de façon sûre.
-- Un nouvel endpoint `GET /top-banned` renvoie les N personnes ayant cumulé le plus de temps de timeout (format curseur sur : `{"member": <nom>, "total_seconds": <int>, "duration_str": <format H-M-S>}`).
+**Systemd deployment**
+An example systemd unit is available at `deploy/skyroulette.service`. Adapt paths and user before enabling. Minimal example:
+```bash
+sudo cp deploy/skyroulette.service /etc/systemd/system/skyroulette.service
+sudo systemctl daemon-reload
+sudo systemctl enable --now skyroulette.service
+```
 
-Frontend
-- La page front affiche désormais un "Leaderboard" reprenant le résultat de `/top-banned`. Le client (`frontend/roulette.js`) récupère ce résultat au chargement et l'actualise après chaque spin.
+**Security & best practices**
+- Never commit your `DISCORD_TOKEN` or `.env` to a public repository.
+- Restrict `ALLOWED_ORIGIN` if serving a public frontend.
+- Pin dependency versions in `requirements.txt` for production deployments.
 
-Notes
-- Le frontend est dans le dossier `frontend/` et est monté sur `/static`.
-- Pour pinner des versions exactes, exécuter `pip freeze > backend/requirements.txt` dans un environnement contrôlé.
-- Durant la Happy Hour, les durées de timeout sont de 1 min et le cooldown entre spins est réduit à 5 minutes.
+**Development notes**
+- The Discord bot is started in a background thread from `backend/main.py`; API routes interact with the bot via the `bot` object.
+- Application state (cooldown, history) is handled by `backend/state.py` and persisted through `backend/timeouts_store.py`.
+
+**Contributing**
+- Please open an issue or a pull request on the repository explaining your change.
+
+**Acknowledgements / Contributors**
+Thank you to the contributors — add names below:
+- [Thomas Byr](https://github.com/ThomasByr) — fix and improvements to frontend and backend.
+
+**References**
+- Code: [backend/main.py](backend/main.py#L1)
+- Frontend: [frontend/index.html](frontend/index.html#L1)
+- Systemd unit: [deploy/skyroulette.service](deploy/skyroulette.service#L1)
+


### PR DESCRIPTION
Include the Apache 2.0 license in the repository and significantly enhance the README to provide clearer information about the project, its features, configuration, and contribution guidelines.