### PR TITLE
Fix `seconds_until_next_spin` and update `can_spin`

### DIFF
--- a/backend/state.py
+++ b/backend/state.py
@@ -95,26 +95,26 @@ def seconds_until_next_spin():
     if remaining.total_seconds() <= 0:
         return 0
 
+    # logic for transitions around happy hours
+    start_hour, end_hour = happy_hour_start_end()
     if not in_happy_hour:
         # check if next spin would be in happy hour
-        start_hour, _ = happy_hour_start_end()
         happy_hour_start = now.replace(hour=start_hour, minute=0, second=0, microsecond=0)
         if last_spin < happy_hour_start <= now + remaining:
             time_until_happy_hour = happy_hour_start - now
             # if the time until happy hour is more than the happy hour cooldown, use the time until happy hour
-            # otherwise, add some extra time to reach the happy hour cooldown
+            # otherwise, add some extra time so that would only have waited the happy hour cooldown in total
             if time_until_happy_hour > happy_hour_cooldown:
-                return int(time_until_happy_hour.total_seconds())
+                remaining = time_until_happy_hour
             else:
-                return int(happy_hour_cooldown.total_seconds())
+                remaining = happy_hour_cooldown - time_until_happy_hour
     if in_happy_hour:
-        # when in happy hour, if the next spin is after the happy hour will end, we need to wait the standard cooldown
-        _, end_hour = happy_hour_start_end()
+        # when in happy hour, if the next spin is after the happy hour will end,
+        # we need to wait the standard cooldown (minus elapsed time)
         happy_hour_end = now.replace(hour=end_hour, minute=0, second=0, microsecond=0)
         if last_spin + happy_hour_cooldown > happy_hour_end:
-            return int(standard_cooldown.total_seconds())
+            remaining = standard_cooldown - elapsed
 
-    # if we did not return yet
     return int(remaining.total_seconds())
 
 


### PR DESCRIPTION
On the first 2 scenarios, the next possible ban will happen during happy hour. The last one is just a UI fix, since the cooldown to wait would have been updated and checked after the happy hour. Each red tick is 5 minutes.

1. scenario 1

When in happy hour, we already have waited for the happy hour cooldown (5 minutes), so the next possible ban happens right when the happy hour starts

<img width="1058" height="245" alt="scenario_0" src="https://github.com/user-attachments/assets/26365a22-8e21-4662-aca3-ecec79dee2b4" />

2. scenario 2

When in happy hour, we wouldn't have waited for the happy hour cooldown entirely, so we add extra during happy hour to match its cooldown

<img width="1058" height="245" alt="scenario_1" src="https://github.com/user-attachments/assets/cce41a28-5d9d-45fe-bc2b-f38c7d146ed7" />


3. scenario 3

When ending happy hour, if the last ban happened after the last 5 minutes (happy hour cooldown), the next ban will happen after the "standard" cooldown have passed

<img width="1058" height="245" alt="scenario_2" src="https://github.com/user-attachments/assets/4d0f67aa-f182-4bca-b7f3-c98ab7addd8a" />
